### PR TITLE
Example to remove IKSSRegistry from four places in site manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,8 @@ For example:
 _unregisterUtility
     Example that removes p4a.subtyper utilities (used in collective.easyslideshow)
 
+remove_kss
+    Example that removes portal_kss and removes IKSSRegistry from four places in the site manager.
 
 See also:
 

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,12 @@ remove_vocabularies
 Some examples that remove various adapters, subscriber and utilities.
 For example:
 
+remove_utility:
+    Remove an interface from all utility registrations.
+    There are several places where an interface like IKSSRegistry can have lodged itself.
+    We need to find them all, otherwise you are not even able to see
+    the ZMI when going to Plone 5.2.
+
 _unregisterUtility
     Example that removes p4a.subtyper utilities (used in collective.easyslideshow)
 

--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,6 @@ remove_multiple_addons
 cleanup_behaviors
     Remove obsolete behaviors
 
-_unregisterUtility
-    Example that removes p4a.subtyper utilities (used in collective.easyslideshow)
-
 remove_vocabularies
     Example that removes p4a.subtyper utilities
 
@@ -100,12 +97,17 @@ remove_vocabularies
 -------------
 
 Some examples that remove various adapters, subscriber and utilities.
+For example:
+
+_unregisterUtility
+    Example that removes p4a.subtyper utilities (used in collective.easyslideshow)
+
 
 See also:
 
-* Use alias_module (see `patches.py`)
-* profiles/migration/componentregistry.xml
-* wildcard.fixpersistentutilities
+* Use alias_module (see `patches.py`_)
+* ``profiles/migration/componentregistry.xml``
+* `wildcard.fixpersistentutilities <https://pypi.org/project/wildcard.fixpersistentutilities/>`_
 
 
 `import_steps.py <https://github.com/collective/collective.migrationhelpers/blob/master/src/collective/migrationhelpers/import_steps.py>`_

--- a/src/collective/migrationhelpers/persistent.py
+++ b/src/collective/migrationhelpers/persistent.py
@@ -27,6 +27,61 @@ def remove_utilities(context=None):
     transaction.commit()
 
 
+def remove_kss(context=None):
+    """Example that removes portal_kss and related utilities
+
+    This code works for me when I run it in Plone 4.3,
+    on a site that originally started at Plone 3 (or maybe even earlier).
+
+    There are several places where IKSSRegistry can have lodged itself.
+    We need to find them all, otherwise you are not even able to see
+    the ZMI when going to Plone 5.2.
+
+    The same might be true for other utilities,
+    like the IZipFileTransportUtility above.
+    """
+    try:
+        from Products.ResourceRegistries.interfaces import IKSSRegistry as iface
+    except ImportError:
+        iface = None
+
+    portal = api.portal.get()
+    if 'portal_kss' in portal:
+        portal.manage_delObjects(['portal_kss'])
+        log.info(u'Removed portal_kss tool.')
+
+    if iface is None:
+        return
+    sm = portal.getSiteManager()
+
+    subscribers = sm.utilities._subscribers[0]
+    if iface in subscribers:
+        del subscribers[iface]
+        log.info(u'Unregistering subscriber for %s', iface)
+
+    adapters = sm.utilities._adapters[0]
+    if iface in adapters:
+        del adapters[iface]
+        log.info(u'Unregistering adapter for %s', iface)
+
+    provided = sm.utilities._provided
+    if iface in provided:
+        del provided[iface]
+        log.info(u'Unregistering provided for %s', iface)
+
+    regs = sm._utility_registrations
+    reg_keys = regs.keys()
+    for reg_key in reg_keys:
+        # registration key is (interface, name)
+        # Note that the interface can probably be there under several names.
+        if iface is reg_key[0]:
+            del regs[reg_key]
+            log.info(u'Unregistering utility registration for %s', reg_key)
+
+    sm.utilities._p_changed = True
+    transaction.commit()
+
+
 def _unregisterUtility(portal):
     """Example that removes p4a.subtyper
     """


### PR DESCRIPTION
I use this in a site that started in Plone 3 (or earlier?), is now at 4.3, and we migrate to 5.2.
If I don't remove IKSSRegistry from all four places, I cannot even see the Plone ZMI in 5.2.

I wonder if the other examples also need this.
So if you want, I could make this into a general method that takes an interface and hunts it down in these four places.
The other example could then call this method.

Also in this PR: minor documentation updates.